### PR TITLE
List keys

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
 v0.3.0 (xxxx-xx-xx)
 
-* Introduction of `list` subcommand that lists values for a given key. (#23)
+* Introduction of `list -key=...` subcommand that lists values for a given key. (#23)
+* Introduction of `list` subcommand (no flags) that lists keys. (#21)
 
 v0.2.0 (2020-04-17)
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,13 @@ subsequently filled in while editing:
 This will list, in alphabetical order, all the unique values for the `tags` key
 as defined in the recipe files' YAML front matter blocks.
 
+### List keys
+
+    cook list
+
+This will list, in alphabetical order, all the unique keys defined in the YAML
+front matter blocks.
+
 ### Validate the formatting of your recipe files
 
     cook validate

--- a/list.go
+++ b/list.go
@@ -42,7 +42,11 @@ func listValuesForKey(key string, values *[]string) filepath.WalkFunc {
 
 func List(key string) {
 	if key == "" {
-		fmt.Println("Functionality to list all keys is not implemented yet. (#21)")
+		uniqueKeys := make([]string, 0)
+		w := walk{prefix: prefix, abstractArray: &uniqueKeys}
+		w.WalkFrontMatter(w.WalkListKeys)
+		sort.Strings(uniqueKeys)
+		PrintArrayOnNewlines(uniqueKeys)
 	} else {
 		values := make([]string, 0)
 		listErr := filepath.Walk(prefix, listValuesForKey(key, &values))

--- a/list.go
+++ b/list.go
@@ -9,7 +9,7 @@ func List(key string) {
 	if key == "" {
 		uniqueKeys := make([]string, 0)
 		w := walk{prefix: prefix, abstractArray: &uniqueKeys}
-		listErr := w.WalkFrontMatter(w.WalkListKeys)
+		listErr := w.WalkFrontMatter(w.ListKeys)
 
 		if listErr != nil {
 			errMsg := "An error occurred while attempting to list keys."

--- a/list.go
+++ b/list.go
@@ -2,63 +2,38 @@ package main
 
 import (
 	"fmt"
-	log "github.com/sirupsen/logrus"
-	"os"
-	"path/filepath"
 	"sort"
 )
-
-func listValuesForKey(key string, values *[]string) filepath.WalkFunc {
-	return func(fullFilepath string, info os.FileInfo, err error) error {
-		shouldSkip := ShouldSkipFile(info, err)
-		if shouldSkip {
-			return nil
-		}
-
-		recipeFile, err := ParseFile(fullFilepath)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"file": fullFilepath,
-			}).Warn(err.Error())
-			return nil
-		}
-
-		frontMatter, err := ParseFrontMatter(recipeFile.FrontMatter)
-		if err != nil {
-			log.WithFields(log.Fields{
-				"file": fullFilepath,
-			}).Warn("Unknown type detected in front matter")
-		}
-
-		valueOfKey := frontMatter[key]
-		for _, v := range valueOfKey {
-			if StringInSlice(v, *values) == false {
-				*values = append(*values, v)
-			}
-		}
-		return nil
-	}
-}
 
 func List(key string) {
 	if key == "" {
 		uniqueKeys := make([]string, 0)
 		w := walk{prefix: prefix, abstractArray: &uniqueKeys}
-		w.WalkFrontMatter(w.WalkListKeys)
+		listErr := w.WalkFrontMatter(w.WalkListKeys)
+
+		if listErr != nil {
+			errMsg := "An error occurred while attempting to list keys."
+			fmt.Printf(errMsg, key)
+		}
+
 		sort.Strings(uniqueKeys)
 		PrintArrayOnNewlines(uniqueKeys)
 	} else {
-		values := make([]string, 0)
-		listErr := filepath.Walk(prefix, listValuesForKey(key, &values))
-		if len(values) == 0 {
-			fmt.Printf("No values were found for key '%s'.\n", key)
-			return
-		}
-		sort.Strings(values)
-		PrintArrayOnNewlines(values)
+		uniqueValues := make([]string, 0)
+		w := walk{prefix: prefix, abstractArray: &uniqueValues, key: key}
+		listErr := w.WalkFrontMatter(w.ListValuesForKey)
+
 		if listErr != nil {
 			errMsg := "An error occurred while attempting to list values for key '%s'."
 			fmt.Printf(errMsg, key)
 		}
+
+		if len(uniqueValues) == 0 {
+			fmt.Printf("No values were found for key '%s'.\n", key)
+			return
+		}
+
+		sort.Strings(uniqueValues)
+		PrintArrayOnNewlines(uniqueValues)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func PrintUsageString() {
 	s := `Usage:
     cook [recipe]
     cook edit [recipe]
-    cook list -key=KEY
+    cook list [-key=KEY]
     cook new -filename=FILENAME
     cook search key:value
     cook validate [recipe]

--- a/util.go
+++ b/util.go
@@ -65,7 +65,7 @@ func (w walk) WalkFrontMatter(f func(fmwalk), params ...interface{}) error {
 	return filepath.Walk(w.prefix, walkGenerator(params))
 }
 
-func (w walk) WalkListKeys(data fmwalk) {
+func (w walk) ListKeys(data fmwalk) {
 	for k, v := range data.fm {
 		key := fmt.Sprintf("%s (%T)", k, v)
 		if StringInSlice(key, *w.abstractArray) == false {

--- a/util.go
+++ b/util.go
@@ -25,6 +25,7 @@ func PrintArrayOnNewlines(a []string) {
 type walk struct {
 	prefix				string
 	abstractArray	*[]string
+	key						string
 }
 
 func (w walk) WalkFrontMatter(f func(map[string][]string) error, params ...interface{}) error {
@@ -62,6 +63,16 @@ func (w walk) WalkListKeys(frontMatter map[string][]string) error {
 		key := fmt.Sprintf("%s (%T)", k, v)
 		if StringInSlice(key, *w.abstractArray) == false {
 			*w.abstractArray = append(*w.abstractArray, key)
+		}
+	}
+	return nil
+}
+
+func (w walk) ListValuesForKey(frontMatter map[string][]string) error {
+	valueOfKey := frontMatter[w.key]
+	for _, v := range valueOfKey {
+		if StringInSlice(v, *w.abstractArray) == false {
+			*w.abstractArray = append(*w.abstractArray, v)
 		}
 	}
 	return nil

--- a/util.go
+++ b/util.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"fmt"
+	log "github.com/sirupsen/logrus"
+	"os"
+	"path/filepath"
 )
 
 func StringInSlice(s string, slice []string) bool {
@@ -17,4 +20,49 @@ func PrintArrayOnNewlines(a []string) {
 	for _, v := range a {
 		fmt.Println(v)
 	}
+}
+
+type walk struct {
+	prefix				string
+	abstractArray	*[]string
+}
+
+func (w walk) WalkFrontMatter(f func(map[string][]string) error, params ...interface{}) error {
+	walkGenerator := func(...interface{}) filepath.WalkFunc {
+		return func(fullFilepath string, info os.FileInfo, err error) error {
+			shouldSkip := ShouldSkipFile(info, err)
+			if shouldSkip {
+				return nil
+			}
+
+			recipeFile, err := ParseFile(fullFilepath)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"file": fullFilepath,
+				}).Warn(err.Error())
+				return nil
+			}
+
+			frontMatter, err := ParseFrontMatter(recipeFile.FrontMatter)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"file": fullFilepath,
+				}).Warn("Unknown type detected in front matter")
+			}
+
+			f(frontMatter)
+			return nil
+		}
+	}
+	return filepath.Walk(w.prefix, walkGenerator(params))
+}
+
+func (w walk) WalkListKeys(frontMatter map[string][]string) error {
+	for k, v := range frontMatter {
+		key := fmt.Sprintf("%s (%T)", k, v)
+		if StringInSlice(key, *w.abstractArray) == false {
+			*w.abstractArray = append(*w.abstractArray, key)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Closes #21.

```
$ cook list
ingredients ([]string)
name ([]string)
tags ([]string)
```

Note: `name` is "incorrectly" of type `[]string` (rather than just `string`) because of the way search works. This should be fixed, perhaps in #20. 