### PR TITLE
Improved error handling for front matter parsing

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,7 @@
+v0.4.0 (xxxx-xx-xx)
+
+* Improve error handling for front matter parsing. (#47)
+
 v0.3.0 (2020-10-20)
 
 * Introduction of `list -key=...` subcommand that lists values for a given key. (#23)

--- a/main.go
+++ b/main.go
@@ -52,7 +52,7 @@ func ParseFrontMatter(fmBytes []byte) (map[string][]string, error) {
 	var rfm map[string]interface{}
 	err := yaml.Unmarshal([]byte(fmBytes), &rfm)
 	if err != nil {
-		return nil, err
+		return nil, errors.New(fmt.Sprintf("Error while unmarshalling yaml: %s", err))
 	}
 
 	// Now make a type assertion into map[string][]string to make querying

--- a/main.go
+++ b/main.go
@@ -71,7 +71,12 @@ func ParseFrontMatter(fmBytes []byte) (map[string][]string, error) {
 			coercedArray := v.([]interface{})
 			vArray := make([]string, len(coercedArray))
 			for _, item := range coercedArray {
-				vArray = append(vArray, item.(string))
+				switch item.(type) {
+				case string:
+					vArray = append(vArray, item.(string))
+				default:
+					return nil, errors.New(fmt.Sprintf("Was not able to process item of type %T in an array. This file's front matter was not parsed further.", item))
+				}
 			}
 			// Get a new slice with the empty strings removed
 			fm[k] = CleanFields(vArray)

--- a/main.go
+++ b/main.go
@@ -190,7 +190,7 @@ func init() {
 	// Log levels
 	log.SetFormatter(&log.TextFormatter{PadLevelText: true})
 	log.SetOutput(os.Stdout)
-	log.SetLevel(log.FatalLevel)
+	log.SetLevel(log.WarnLevel)
 }
 
 type flagArray []string

--- a/util.go
+++ b/util.go
@@ -54,7 +54,7 @@ func (w walk) WalkFrontMatter(f func(fmwalk), params ...interface{}) error {
 			if err != nil {
 				log.WithFields(log.Fields{
 					"file": fullFilepath,
-				}).Warn("Unknown type detected in front matter")
+				}).Warn(fmt.Sprintf("An error occurred while parsing front matter: %s", err.Error()))
 			}
 
 			fmwalkData := fmwalk{fm: frontMatter, fullFilepath: fullFilepath}


### PR DESCRIPTION
Fixes #47 

Also sets the log level to `WARN` for now. There are plans to be able to dynamically change this in the future using a flag.